### PR TITLE
drop internal checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ This GitHub Action does not have any outputs. Please instead inspect the logs to
       docker:
         runs-on: ubuntu-latest
         steps:
-          -
-            name: Register, Build, and Publish a Speckle Function
+          - name: Checkout
+            uses: actions/checkout@v5 # <-- CONFIGURE CHECKOUT FOR YOUR CODE
+          - name: Register, Build, and Publish a Speckle Function
             uses: specklesystems/speckle-automate-github-composite-action
             with:
               speckle_token: ${{ secrets.SPECKLE_FUNCTION_PUBLISH_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - uses: actions/checkout@v4 # checkout the repository in which this GitHub Action is being used.
       - name: Validate inputs
         shell: bash
         run: |


### PR DESCRIPTION
The internal `actions/checkout` here overwrites external consumers' own checkouts. Usually ok, but causing problems in some internal repos that are configured with LFS. (This overwrites that.)

Removes step and adds to docs (although implied)